### PR TITLE
Fix thumbnails not being deleted when banning images.

### DIFF
--- a/Hayden.WebServer/Data/HaydenDataProvider.cs
+++ b/Hayden.WebServer/Data/HaydenDataProvider.cs
@@ -338,7 +338,7 @@ namespace Hayden.WebServer.Data
 					var fullFilename = Common.CalculateFilename(config.Value.Data.FileLocation, board.ShortName, Common.MediaType.Image,
 						file.Sha256Hash, file.Extension);
 					var thumbFilename = Common.CalculateFilename(config.Value.Data.FileLocation, board.ShortName, Common.MediaType.Thumbnail,
-						file.Sha256Hash, file.Extension);
+						file.Sha256Hash, "jpg");
 
 					System.IO.File.Delete(fullFilename);
 					System.IO.File.Delete(thumbFilename);


### PR DESCRIPTION
Thumbnails are hardcoded to end in `.jpg` but the code for banning images tries to use the source file's extension for the thumbnail's path too.